### PR TITLE
Declare key parameter as optional

### DIFF
--- a/ng2-slugify.ts
+++ b/ng2-slugify.ts
@@ -3,7 +3,7 @@ import {Charmaps} from './charmaps';
 export class Slug {
   private maps: Object;
 
-  constructor(key: string) {
+  constructor(key?: string) {
     let charmaps = new Charmaps();
     let k = (key) ? key : 'default';
     this.maps = charmaps.getMaps(k);


### PR DESCRIPTION
Using Slug class without parameter key `private slug = new Slug();` throws exception "Supplied parameters do not match any signature of call target".

Parameter key should be declared as optional.